### PR TITLE
port src/webapp to TypeScript latest react

### DIFF
--- a/src/webapp_ts/package.json
+++ b/src/webapp_ts/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "webapp_ts",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@types/react": "^17.0.2",
+    "@types/react-dom": "^17.0.2",
+    "classnames": "^2.3.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-select": "^5.7.0",
+    "sass": "^1.58.3",
+    "three": "^0.171.0",
+    "typescript": "^4.5.4",
+    "uuid": "^9.0.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
+    "@babel/preset-react": "^7.14.5",
+    "@babel/preset-typescript": "^7.15.0",
+    "babel-loader": "^8.2.2",
+    "css-loader": "^6.2.0",
+    "eslint": "^7.32.0",
+    "html-webpack-plugin": "^5.3.2",
+    "jest": "^27.0.6",
+    "style-loader": "^3.2.1",
+    "ts-loader": "^9.2.3",
+    "webpack": "^5.51.1",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.0.0"
+  }
+}

--- a/src/webapp_ts/src/App.tsx
+++ b/src/webapp_ts/src/App.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from "react";
+
+import * as c from "./constants";
+import {
+    DEFAULT_HUB_STATE,
+    connectToHub,
+    addHubStateUpdatedListener,
+    removeHubStateUpdatedListener,
+    giveTreat,
+} from "./util/hubState";
+
+import { Header } from "./Header";
+import { HubStateDialog } from "./HubStateDialog";
+
+import { ArmView } from "./ArmView";
+import MenuLeft from "./MenuLeft";
+
+function App() {
+    const [hubState, setHubState] = useState(DEFAULT_HUB_STATE);
+    const [isHubStateDialogOpen, setIsHubStateDialogOpen] = useState(false);
+
+    useEffect(() => {
+        addHubStateUpdatedListener(handleHubStateUpdated);
+        connectToHub();
+
+        return () => removeHubStateUpdatedListener(handleHubStateUpdated);
+    }, []);
+
+    const handleHubStateUpdated = (newState: any) => {
+        setHubState({ ...newState });
+    };
+
+    return (
+        <div>
+            <Header
+                hubState={hubState}
+                isHubStateDialogOpen={isHubStateDialogOpen}
+                onHubStateDialogOpen={() => setIsHubStateDialogOpen(true)}
+            />
+            <div className="wrap">
+                <div className="left-frame" id="gap">
+                    <div className="sidebar-buttons">
+                        <MenuLeft hubState={hubState} />
+                    </div>
+                </div>
+                <div className="right-frame">
+                    <div className="bar-panel">
+                        <div className="bar-6"></div>
+                        <div className="bar-7"></div>
+                        <div className="bar-8"></div>
+                        <div className="bar-9">
+                            <div className="bar-9-inside"></div>
+                        </div>
+                        <div className="bar-10"></div>
+                    </div>
+                    <div className="corner-bg">
+                        <div className="corner"></div>
+                    </div>
+                    <div className="content">
+                        <ArmView hubState={hubState} />
+                    </div>
+                </div>
+            </div>
+            <HubStateDialog
+                hubState={hubState}
+                isOpen={isHubStateDialogOpen}
+                onClose={() => setIsHubStateDialogOpen(false)}
+            />
+        </div>
+    );
+}
+
+export default App;

--- a/src/webapp_ts/src/ArmView/Arm3d.tsx
+++ b/src/webapp_ts/src/ArmView/Arm3d.tsx
@@ -1,0 +1,158 @@
+import React, { useRef, useEffect, useMemo } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+import { STLLoader } from "three/examples/jsm/loaders/STLLoader";
+import { degToRad } from "three/src/math/MathUtils.js";
+
+const scene = new THREE.Scene();
+let camera: THREE.PerspectiveCamera | null = null;
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+
+interface Arm3DProps {
+    armParts: any[];
+    currentAngles?: number[];
+}
+
+const Arm3D: React.FC<Arm3DProps> = ({ armParts, currentAngles = [] }) => {
+    const mountRef = useRef<HTMLDivElement | null>(null);
+    const parts = useMemo(() => {
+        return !armParts
+            ? null
+            : armParts.map((part) => ({
+                  threeDObject: null,
+                  part,
+              }));
+    }, [armParts]);
+
+    useEffect(() => {
+        if (!parts || !currentAngles) return;
+
+        const mount = mountRef.current;
+        if (!mount) return;
+
+        camera = new THREE.PerspectiveCamera(
+            75,
+            mount.clientWidth / mount.clientHeight,
+            0.1,
+            5000
+        );
+
+        // Scene setup
+        scene.clear();
+        renderer.setSize(mount.clientWidth, mount.clientHeight);
+        mount.replaceChildren(renderer.domElement);
+
+        // Lighting
+        const ambientLight = new THREE.AmbientLight(0x666666);
+        scene.add(ambientLight);
+        const directionalLight = new THREE.DirectionalLight(0xffffff, 3);
+        directionalLight.position.set(0, 20, 20);
+        scene.add(directionalLight);
+        const directionalLight2 = new THREE.DirectionalLight(0xffffff, 2);
+        directionalLight2.position.set(0, -20, -20);
+        scene.add(directionalLight2);
+
+        loadStlFiles().then(() => {
+            let parent = scene;
+            for (const part of parts) {
+                parent.add(part.threeDObject);
+                part.threeDObject.position.set(
+                    part.part.position.x - (part.part.rotationOffset?.x || 0),
+                    part.part.position.y - (part.part.rotationOffset?.y || 0),
+                    part.part.position.z - (part.part.rotationOffset?.z || 0)
+                );
+                parent = part.threeDObject;
+            }
+
+            // Camera position
+            camera!.position.x = -700;
+            camera!.position.y = 300;
+            camera!.position.z = 200;
+
+            const controls = new OrbitControls(camera!, renderer.domElement);
+            controls.target.set(-200, 260, 300);
+            controls.update();
+        });
+
+        // Cleanup on unmount
+        return () => {
+            mount.removeChild(renderer.domElement);
+        };
+    }, [parts]);
+
+    useEffect(() => {
+        if (!parts || !currentAngles) return;
+
+        const movables = parts.filter((part) => !part.part.fixed);
+
+        const animate = () => {
+            requestAnimationFrame(animate);
+
+            movables.forEach((part, index) => {
+                if (part && part.threeDObject) {
+                    if (index < currentAngles.length) {
+                        const axis = part.part.rotationAxis || "x";
+                        const initial = part.part.initialRotation?.[axis] || 0;
+                        const minAngle = part.part.minAngle || 0;
+                        const maxAngle =
+                            part.part.maxAngle || part.part.motor_range || 270;
+                        const midAngle = minAngle + (maxAngle - minAngle) / 2;
+                        let newAngle =
+                            midAngle - currentAngles[index] + initial;
+                        if (part.part.invertRotation) {
+                            newAngle *= -1;
+                        }
+                        part.threeDObject.rotation[axis] = degToRad(newAngle);
+                    }
+                }
+            });
+            renderer.render(scene, camera!);
+        };
+
+        animate();
+    }, [parts, currentAngles]);
+
+    async function loadStlFiles() {
+        const loader = new STLLoader();
+        const material = new THREE.MeshStandardMaterial({
+            color: 0xff5533,
+        });
+
+        const promises = parts.map((part) => {
+            return new Promise<void>((resolve) => {
+                loader.load("arm-parts/" + part.part.file, (geometry) => {
+                    const mesh = new THREE.Mesh(geometry, material);
+                    mesh.geometry.center();
+                    const pivot = new THREE.Object3D();
+                    pivot.add(mesh);
+
+                    if (part.part.rotationOffset) {
+                        mesh.position.setX(part.part.rotationOffset.x || 0);
+                        mesh.position.setY(part.part.rotationOffset.y || 0);
+                        mesh.position.setZ(part.part.rotationOffset.z || 0);
+                    }
+
+                    if (part.part.initialRotation) {
+                        pivot.rotation.x = degToRad(
+                            part.part.initialRotation.x || 0
+                        );
+                        pivot.rotation.y = degToRad(
+                            part.part.initialRotation.y || 0
+                        );
+                        pivot.rotation.z = degToRad(
+                            part.part.initialRotation.z || 0
+                        );
+                    }
+                    part.threeDObject = pivot;
+                    resolve();
+                });
+            });
+        });
+
+        await Promise.all(promises);
+    }
+
+    return <div ref={mountRef} style={{ width: "100%", height: "100%" }} />;
+};
+
+export default Arm3D;

--- a/src/webapp_ts/src/ArmView/ArmAngleControl.tsx
+++ b/src/webapp_ts/src/ArmView/ArmAngleControl.tsx
@@ -1,0 +1,167 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+
+import st from "./ArmAngleControl.module.css";
+
+interface ArmControlProps {
+    part: any;
+    currentAngle: number;
+    setAngle: number;
+    onSetAngle: (angle: number) => void;
+}
+
+export function ArmControl({ part, currentAngle, setAngle, onSetAngle }: ArmControlProps) {
+    const [grabberSelected, setGrabberSelected] = useState(false);
+    const [grabberHovered, setGrabberHovered] = useState(false);
+    const [changingAngle, setChangingAngle] = useState<number | null>(null);
+    const svgRef = useRef<SVGSVGElement | null>(null);
+    const motorRange = part.motorRange || 180;
+    const minAngle = part.minAngle || 0;
+    const maxAngle = part.maxAngle || motorRange;
+    const midAngle = (maxAngle + minAngle) / 2;
+
+    useEffect(() => {
+        const handleMouseMove = (e: MouseEvent | TouchEvent) => {
+            if (!svgRef.current || !grabberSelected || !(e instanceof MouseEvent || e.touches)) {
+                return;
+            }
+            const clientX = e instanceof MouseEvent ? e.clientX : e.touches[0].clientX;
+            const clientY = e instanceof MouseEvent ? e.clientY : e.touches[0].clientY;
+            const rect = svgRef.current.getBoundingClientRect();
+            const x = clientX - rect.left;
+            const y = clientY - rect.top;
+            const angle = Math.atan2(y - 100, x - 100) * (360 / Math.PI);
+            onSetAngle(angle * -1);
+
+            console.log("Mouse move", { x, y, angle });
+        };
+
+        const handleMouseUp = () => {
+            grabberSelected && setGrabberSelected(false);
+        };
+
+        document.addEventListener("mousemove", handleMouseMove);
+        document.addEventListener("mouseup", handleMouseUp);
+        document.addEventListener("touchmove", handleMouseMove);
+        document.addEventListener("touchend", handleMouseUp);
+
+        return () => {
+            document.removeEventListener("mousemove", handleMouseMove);
+            document.removeEventListener("mouseup", handleMouseUp);
+            document.removeEventListener("touchmove", handleMouseMove);
+            document.removeEventListener("touchend", handleMouseUp);
+        };
+    }, [grabberSelected, onSetAngle, motorRange]);
+
+    const handleGrabberMouseDown = useCallback(() => {
+        setGrabberSelected(true);
+    }, []);
+
+    const handleAngleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        // allow small increments to be set without needing to press enter
+        if (!changingAngle && Math.abs(setAngle - Number.parseFloat(e.target.value)) < 2) {
+            handleAngleInputBlur(e);
+        } else {
+            setChangingAngle(Number.parseFloat(e.target.value));
+        }
+    }, [changingAngle, setAngle]);
+
+    const handleAngleInputBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+        onSetAngle(parseInt(e.target.value));
+        setChangingAngle(null);
+    }, [onSetAngle]);
+
+    const handleAngleInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            handleAngleInputBlur(e as unknown as React.FocusEvent<HTMLInputElement>);
+        }
+    }, [handleAngleInputBlur]);
+
+    const translateAngle = (angle: number) => {
+        return 90 + midAngle - angle;
+    };
+
+    return (
+        <div className={st.container}>
+            <div className={st.currentAngle}>
+                {parseFloat(currentAngle.toString()).toFixed(3)}&deg;
+            </div>
+            <div className={st.textLabels}>
+                <label>{part.name}</label>
+                <div>
+                    <div className={st.angleInputContainer}>
+                        <input
+                            type="number"
+                            min={minAngle}
+                            max={maxAngle}
+                            className={st.angleInput}
+                            value={changingAngle || setAngle?.toFixed(0) || 0}
+                            onChange={handleAngleInputChange}
+                            onBlur={handleAngleInputBlur}
+                            onKeyDown={handleAngleInputKeyDown}
+                        />
+                        &deg;
+                    </div>
+                </div>
+            </div>
+            <svg width="200" height="100" viewBox="0 0 200 200" ref={svgRef}>
+                <circle
+                    cx="100"
+                    cy="100"
+                    r={70}
+                    fill="none"
+                    stroke="#c777"
+                    strokeWidth="10"
+                />
+                <rect
+                    className={st.grabber}
+                    x="10"
+                    y="90"
+                    height="20"
+                    width="50"
+                    rx="10"
+                    fill="#9d6" // from lcars.css
+                    transform={`rotate(${translateAngle(setAngle)} 100 100)`}
+                    opacity={grabberSelected ? 1 : grabberHovered ? 0.8 : 0.7}
+                    onMouseDown={handleGrabberMouseDown}
+                    onTouchStart={handleGrabberMouseDown}
+                    onMouseEnter={() => setGrabberHovered(true)}
+                    onMouseLeave={() => setGrabberHovered(false)}
+                />
+                <line
+                    x1="55"
+                    y1="100"
+                    x2="100"
+                    y2="100"
+                    fill="none"
+                    stroke="#ffff00"
+                    strokeWidth="1"
+                    transform={`rotate(${translateAngle(
+                        currentAngle || 0
+                    )} 100 100)`}
+                />
+                <line
+                    x1="0"
+                    y1="100"
+                    x2="100"
+                    y2="100"
+                    fill="none"
+                    stroke="#770000"
+                    strokeWidth="4"
+                    strokeDasharray="5"
+                    transform={`rotate(${translateAngle(minAngle)} 100 100)`}
+                />
+                <line
+                    x1="25"
+                    y1="100"
+                    x2="100"
+                    y2="100"
+                    fill="none"
+                    stroke="#770000"
+                    strokeWidth="4"
+                    strokeDasharray="5"
+                    transform={`rotate(${translateAngle(maxAngle)} 100 100)`}
+                />
+            </svg>
+        </div>
+    );
+}

--- a/src/webapp_ts/src/ArmView/ArmAngleControls.tsx
+++ b/src/webapp_ts/src/ArmView/ArmAngleControls.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo, useCallback } from "react";
+
+import { sendSetAngles } from "../util/hubMessages";
+import { ArmControl } from "./ArmAngleControl";
+
+import st from "./ArmAngleControls.module.css";
+
+interface ArmAngleControlsProps {
+    parts: any[];
+    currentAngles: number[];
+    setAngles: number[];
+}
+
+export function ArmAngleControls({ parts, currentAngles, setAngles }: ArmAngleControlsProps) {
+    const handleOnSetAngle = useCallback((angleIndex: number, angle: number) => {
+        console.log("setting angle", { angleIndex, angle });
+        const newAngles = [...setAngles];
+        newAngles[angleIndex] = angle;
+        sendSetAngles(newAngles);
+    }, [setAngles]);
+
+    const controls = useMemo(() => {
+        if (!parts?.length) return null;
+
+        const cOut = [];
+        for (let i = parts.length - 1; i >= 0; i--) {
+            cOut.push(
+                <ArmControl
+                    key={i}
+                    part={parts[i]}
+                    currentAngle={currentAngles[i]}
+                    setAngle={setAngles[i]}
+                    onSetAngle={(newAngle) => handleOnSetAngle(i, newAngle)}
+                />
+            );
+        }
+        return cOut;
+    }, [parts, currentAngles, setAngles, handleOnSetAngle]);
+
+    return (
+        <div>
+            <h4>Arm Angles</h4>
+            <div className={st.angleControls}>{controls}</div>
+        </div>
+    );
+}

--- a/src/webapp_ts/src/ArmView/index.tsx
+++ b/src/webapp_ts/src/ArmView/index.tsx
@@ -1,0 +1,33 @@
+import React, { useMemo } from "react";
+
+import Arm3D from "./Arm3d";
+
+import st from "./index.module.css";
+import { ArmAngleControls } from "./ArmAngleControls";
+
+const lastCurrentAngles = null;
+
+export function ArmView({ hubState }: { hubState: any }) {
+    const parts = useMemo(
+        () => hubState.arm_config.arm_parts?.filter((p: any) => !p.fixed),
+        [hubState.arm_config.arm_parts]
+    );
+
+    return (
+        <div className={st.container}>
+            <div className={st.visualization}>
+                <Arm3D
+                    armParts={hubState.arm_config.arm_parts}
+                    currentAngles={hubState.current_angles}
+                />
+            </div>
+            <div className={st.controls}>
+                <ArmAngleControls
+                    parts={parts}
+                    currentAngles={hubState.current_angles}
+                    setAngles={hubState.set_angles}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/webapp_ts/src/Header.tsx
+++ b/src/webapp_ts/src/Header.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+import { LabeledText } from "./components/LabeledText";
+
+import { classnames } from "./util/classNames";
+import st from "./Header.module.css";
+
+interface HeaderProps {
+  hubState: any;
+  isHubStateDialogOpen: boolean;
+  onHubStateDialogOpen: () => void;
+}
+
+export function Header({
+  hubState,
+  isHubStateDialogOpen,
+  onHubStateDialogOpen,
+}: HeaderProps) {
+  const system_stats = hubState.system_stats;
+
+  const dialogCls = classnames("wrap", st.header);
+  const topLeftCls = classnames(
+    "left-frame-top",
+    "sidebar-buttons",
+    st.leftFrameTop,
+    {
+      predicate: isHubStateDialogOpen,
+      value: st.activeDialogTrigger,
+    }
+  );
+
+  return (
+    <div className={dialogCls}>
+      <div className={topLeftCls} onClick={onHubStateDialogOpen}>
+        Hub State
+      </div>
+
+      <div className="right-frame-top">
+        <div className={`padded-1 flex-row`}>
+          <div className={st.rightFrameContent}>
+            <div className={`flex-row ${st.stats}`}>
+              <div className={st.statsColumn}>
+                <LabeledText label="hub status">
+                  {hubState.hubConnStatus}
+                </LabeledText>
+              </div>
+              {hubState.hubConnStatus === "online" && (
+                <>
+                  <div className={st.statsColumn}>
+                    <LabeledText label="cpu temp">
+                      {system_stats?.cpu_temp.toFixed(1)}˚
+                    </LabeledText>
+                    <LabeledText label="cpu util">
+                      {system_stats?.cpu_util.toFixed(1)}%
+                    </LabeledText>
+                    <LabeledText label="ram util">
+                      {system_stats?.ram_util.toFixed(1)}%
+                    </LabeledText>
+                  </div>
+
+                  <div className={st.statsColumn}></div>
+                </>
+              )}
+            </div>
+          </div>
+          <div className={st.title}>
+            <h1>Strongarm</h1>
+          </div>
+        </div>
+        <div className="top-corner-bg">
+          <div className="top-corner"></div>
+        </div>
+        <div className="bar-panel">
+          <div className="bar-1"></div>
+          <div className="bar-2"></div>
+          <div className="bar-3"></div>
+          <div className="bar-4">
+            <div className="bar-4-inside"></div>
+          </div>
+          <div className="bar-5"></div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/webapp_ts/src/HubStateDialog.tsx
+++ b/src/webapp_ts/src/HubStateDialog.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+
+import { classnames } from "./util/classNames";
+import { Button } from "./components/Button";
+import st from "./HubStateDialog.module.css";
+
+import { getStateFromCentralHub } from "./util/hubState";
+
+const LOCAL_STATE = 0;
+const REMOTE_STATE = 1;
+
+export function HubStateDialog({ hubState, isOpen, onClose }) {
+    const [whichState, setWhichState] = useState(LOCAL_STATE);
+    const [remoteState, setRemoteState] = useState({});
+    const [isLoading, setIsLoading] = useState(false);
+
+    const closedClass = !isOpen ? st.closed : null;
+
+    function handleRemoteLoadError(e: any) {
+        console.error("error loading remote state", e);
+    }
+
+    async function loadRemoteState() {
+        setRemoteState(await getStateFromCentralHub());
+    }
+
+    function handleStateChange(newState: number) {
+        setIsLoading(true);
+        setWhichState(newState);
+
+        if (newState === REMOTE_STATE) {
+            loadRemoteState();
+        }
+    }
+
+    function handleDialogClick(e: React.MouseEvent) {
+        e.preventDefault();
+        e.stopPropagation();
+    }
+
+    const displayedState = whichState === REMOTE_STATE ? remoteState : hubState;
+
+    return (
+        <div
+            className={classnames(st.dialogBackdrop, closedClass)}
+            onClick={onClose}
+        >
+            <div
+                className={classnames(st.dialog, closedClass)}
+                onClick={handleDialogClick}
+            >
+                <div className={classnames(st.dialogContent, closedClass)}>
+                    {isOpen && (
+                        <div className={classnames(st.dialogViewport)}>
+                            <div
+                                className={classnames(
+                                    "buttons",
+                                    st.videoSelector
+                                )}
+                            >
+                                <Button
+                                    isSelected={whichState === LOCAL_STATE}
+                                    onClick={() =>
+                                        handleStateChange(LOCAL_STATE)
+                                    }
+                                >
+                                    local hub state
+                                </Button>
+                                <Button
+                                    isSelected={whichState === REMOTE_STATE}
+                                    onClick={() =>
+                                        handleStateChange(REMOTE_STATE)
+                                    }
+                                >
+                                    remote hub state
+                                </Button>
+                            </div>
+                            <pre>
+                                <code className={st.dialogCode}>
+                                    {JSON.stringify(displayedState, null, 2)}
+                                </code>
+                            </pre>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/webapp_ts/src/MenuLeft/ArmConfig.tsx
+++ b/src/webapp_ts/src/MenuLeft/ArmConfig.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback } from "react";
+
+import { sendArmConfigSelected } from "../util/hubMessages";
+import st from "./ArmConfig.module.css";
+
+interface ArmConfigProps {
+  hubState: {
+    arm_config_files: string[];
+    arm_config: {
+      filename: string;
+    };
+  };
+}
+
+export function ArmConfig({ hubState }: ArmConfigProps) {
+  const handleArmConfigClick = useCallback((file: string) => {
+    sendArmConfigSelected(file);
+  }, []);
+
+  console.log("rendering ArmConfig", { hubState });
+  return (
+    <div className={st.container}>
+      <div className={st.title}>Select arm config</div>
+      <div>
+        {hubState.arm_config_files.map((file, index) => (
+          <div key={index}>
+            <a
+              onClick={() => handleArmConfigClick(file)}
+              className={
+                (file === hubState.arm_config.filename && "selected") || null
+              }
+            >
+              {file}
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/webapp_ts/src/MenuLeft/SavedPositions/index.tsx
+++ b/src/webapp_ts/src/MenuLeft/SavedPositions/index.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useCallback, useMemo } from "react";
+
+import { classnames as cx } from "../../util/classNames";
+import st from "./index.module.css";
+import { SavePositionDialog } from "./SavePositionDialog";
+import { PositionMenu } from "./PositionMenu";
+import { anglesCloseEnough } from "../../util/angle_utils";
+
+interface HubState {
+  saved_positions: Position[];
+  set_angles: number[];
+  current_angles: number[];
+}
+
+interface Position {
+  uuid: string;
+  name: string;
+  description: string;
+  angles: number[];
+}
+
+interface SavedPositionsProps {
+  hubState: HubState;
+}
+
+export function SavedPositions({ hubState }: SavedPositionsProps) {
+  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
+  const [selectedPosition, setSelectedPosition] = useState<Position | null>(null);
+
+  const handleAddPosition = useCallback(() => {
+    setIsSaveDialogOpen(true);
+  }, []);
+
+  const handleSaveDialogClose = useCallback(() => {
+    setIsSaveDialogOpen(false);
+  }, []);
+
+  const handlePositionClick = useCallback((position: Position) => {
+    setSelectedPosition(position);
+  }, []);
+
+  const handleUnselectPosition = useCallback(() => {
+    setSelectedPosition(null);
+  }, []);
+
+  return (
+    <>
+      <div className={cx(st.container, selectedPosition && st.hasSelected)}>
+        <a onClick={handleAddPosition}>Save Current Position</a>
+        <div className={st.title}>Saved Positions</div>
+
+        <div className={st.positionList}>
+          {hubState.saved_positions.map((position, index) => (
+            <PositionItem
+              key={index}
+              hubState={hubState}
+              position={position}
+              onClick={handlePositionClick}
+            />
+          ))}
+        </div>
+      </div>
+      {selectedPosition && (
+        <PositionMenu
+          hubState={hubState}
+          positionId={selectedPosition.uuid}
+          onClose={handleUnselectPosition}
+        />
+      )}
+
+      <SavePositionDialog
+        isOpen={isSaveDialogOpen}
+        onClose={handleSaveDialogClose}
+        hubState={hubState}
+      />
+    </>
+  );
+}
+
+interface PositionItemProps {
+  hubState: HubState;
+  position: Position;
+  onClick: (position: Position) => void;
+}
+
+function PositionItem({ hubState, position, onClick }: PositionItemProps) {
+  const closeEnough = useMemo(
+    () => anglesCloseEnough(hubState.set_angles, position.angles),
+    [hubState.set_angles, position.angles]
+  );
+
+  return (
+    <a
+      className={cx("secondary", closeEnough && "selected")}
+      onClick={() => onClick(position)}
+    >
+      {position.name}
+    </a>
+  );
+}

--- a/src/webapp_ts/src/MenuLeft/index.tsx
+++ b/src/webapp_ts/src/MenuLeft/index.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback, useState, useMemo } from "react";
+
+import { classnames } from "../util/classNames";
+import st from "./index.module.css";
+import { BackButton } from "../components/icons/BackButton";
+
+import { ArmConfig } from "./ArmConfig";
+import { SavedPositions } from "./SavedPositions";
+import { sendSetAngles } from "../util/hubMessages";
+
+const BASE_NODE_NAME = "Menu Root";
+
+const MenuLeft = ({ hubState }) => {
+    const [itemIndexSelected, setItemIndexSelected] = useState<number | null>(null);
+    const isAtRootMenu = itemIndexSelected === null;
+
+    /*
+        // the name of the menu item that will be displayed
+        name: string
+
+        // the action to take when the item is clicked
+        action: string?
+
+        // the component to render in place of the menu items when when
+        // the item is clicked
+        component: React.Component?
+    */
+    const items = useMemo(
+        () => [
+            {
+                name: "Arm Config",
+                component: <ArmConfig hubState={hubState} />,
+            },
+            {
+                name: "Saved Positions",
+                component: <SavedPositions hubState={hubState} />,
+            },
+            { name: "Sequence", component: <div>Sequence component here</div> },
+        ],
+        [hubState]
+    );
+
+    const movablePartCount = useMemo(
+        () =>
+            hubState.arm_config.arm_parts.reduce(
+                (acc: number, part: { movable: boolean }) => (part.movable ? acc + 1 : acc),
+                0
+            ),
+        [hubState.arm_config.arm_parts]
+    );
+
+    const menuName = isAtRootMenu
+        ? BASE_NODE_NAME
+        : items[itemIndexSelected].name;
+
+    const handleMenuClick = useCallback((itemIndex: number) => {
+        setItemIndexSelected(itemIndex);
+    }, []);
+
+    const handleBackClick = useCallback(() => {
+        setItemIndexSelected(null);
+    }, []);
+
+    const handleResetClick = useCallback(() => {
+        sendSetAngles(Array(movablePartCount).fill(90));
+    }, [movablePartCount]);
+
+    const buttonsStyle = isAtRootMenu ? { left: 0 } : { left: "-100%" };
+    const componentStyle = isAtRootMenu ? { left: "100%" } : { left: 0 };
+
+    return (
+        <div className={st.menuLeft}>
+            <h3 className={st.topControls}>
+                <div>
+                    {!isAtRootMenu && <BackButton onClick={handleBackClick} />}
+                </div>
+                <div className={st.menuName}>{menuName}</div>
+            </h3>
+            <div className={st.menuButtons} style={buttonsStyle}>
+                {items.map((item, index) => (
+                    <a key={index} onClick={() => handleMenuClick(index)}>
+                        {item.name}
+                    </a>
+                ))}
+                <div className={st.vspacer} />
+                <a onClick={handleResetClick}>Reset All Angles</a>
+            </div>
+            <div className={st.componentContainer} style={componentStyle}>
+                {itemIndexSelected != null &&
+                    items[itemIndexSelected].component}
+            </div>
+        </div>
+    );
+};
+
+export default MenuLeft;

--- a/src/webapp_ts/src/components/Button.tsx
+++ b/src/webapp_ts/src/components/Button.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import { classnames } from "../util/classNames";
+import st from "./Button.module.css";
+
+interface ButtonProps {
+  className?: string;
+  children: React.ReactNode;
+  isSelected?: boolean;
+  onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+}
+
+export function Button({ className, children, isSelected, onClick }: ButtonProps) {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    onClick(e);
+  };
+
+  const buttonCls = classnames(className, "button", st.button, {
+    predicate: isSelected,
+    value: st.buttonSelected,
+  });
+  return (
+    <div className={buttonCls} onClick={handleClick}>
+      <a onClick={handleClick}>{children}</a>
+    </div>
+  );
+}

--- a/src/webapp_ts/src/components/LabeledText.tsx
+++ b/src/webapp_ts/src/components/LabeledText.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import { classnames } from "../util/classNames";
+import st from "./LabeledText.module.css";
+
+interface LabeledTextProps {
+  label: string;
+  children: React.ReactNode;
+  isSelected?: boolean;
+  onClick?: () => void;
+}
+
+export function LabeledText({ label, children, isSelected, onClick }: LabeledTextProps) {
+  return (
+    <div className={st.labeledText} onClick={onClick}>
+      <div className={st.label}>{label}:</div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/src/webapp_ts/src/constants.ts
+++ b/src/webapp_ts/src/constants.ts
@@ -1,0 +1,8 @@
+export const RGB_VIDEO = 0;
+export const DEPTH_VIDEO = 1;
+
+export const DEPTH_MAP_OVERLAY = 1;
+export const OBJECTS_OVERLAY = 2;
+
+export const VIDEO_FEED_PORT = 5001;
+export const DEPTH_VIDEO_FEED_PORT = 5002;

--- a/src/webapp_ts/src/index.css
+++ b/src/webapp_ts/src/index.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  /* width and height are for a 7" elecrow display */
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
+    monospace;
+}

--- a/src/webapp_ts/src/index.tsx
+++ b/src/webapp_ts/src/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
+
+ReactDOM.render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>,
+    document.getElementById("root")
+);
+
+// If you want to start measuring performance in your app, pass a function
+// to log results (for example: reportWebVitals(console.log))
+// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
+reportWebVitals();

--- a/src/webapp_ts/src/util/angle_utils.ts
+++ b/src/webapp_ts/src/util/angle_utils.ts
@@ -1,0 +1,10 @@
+const ANGLE_CLOSE_ENOUGH = 0.5;
+
+export function anglesCloseEnough(anglesA: number[], anglesB: number[]): boolean {
+    for (let i = 0; i < anglesA.length; i++) {
+        if (Math.abs(anglesA[i] - anglesB[i]) > ANGLE_CLOSE_ENOUGH) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/webapp_ts/src/util/classNames.ts
+++ b/src/webapp_ts/src/util/classNames.ts
@@ -1,0 +1,16 @@
+export function classnames(...args: any[]): string {
+  let classes = "";
+  for (const arg of args) {
+    if (!arg) {
+      continue;
+    }
+    if (typeof arg === "object") {
+      if (arg.predicate) {
+        classes += ` ${arg.value.toString()}`;
+      }
+    } else {
+      classes += ` ${arg.toString()}`;
+    }
+  }
+  return classes;
+}

--- a/src/webapp_ts/src/util/hubMessages.ts
+++ b/src/webapp_ts/src/util/hubMessages.ts
@@ -1,0 +1,21 @@
+import { webSocket, logMessage } from "./hubState";
+
+export function sendHubStateUpdate(data: any) {
+    logMessage("sending state update", { data, webSocket });
+    if (webSocket) {
+        webSocket.send(
+            JSON.stringify({
+                type: "updateState",
+                data,
+            })
+        );
+    }
+}
+
+export function sendSetAngles(angles: number[]) {
+    sendHubStateUpdate({ set_angles: angles });
+}
+
+export function sendArmConfigSelected(file: string) {
+    sendHubStateUpdate({ arm_config_selected: file });
+}

--- a/src/webapp_ts/src/util/hubState.ts
+++ b/src/webapp_ts/src/util/hubState.ts
@@ -1,0 +1,229 @@
+import "react";
+
+const urlParams = new URLSearchParams(window.location.search);
+const debugThings = urlParams.get("debug")?.split(",") || [];
+
+export const logMessages = debugThings.indexOf("messages") >= 0;
+
+// How often to check if hub is really still alive
+const HUB_PING_INTERVAL = 1000;
+// with us pinging every 1000ms, there should
+// never be a lapse of more than 1500 between
+// messages from hub.  Otherwise, we show "offline"
+const MIN_HUB_UPDATE_INTERVAL = 1500;
+
+export const HUB_PORT = process.env.HUB_PORT || 5800;
+
+export const HUB_HOST = `${window.location.hostname}:${HUB_PORT}`;
+
+export const HUB_URL = `ws://${HUB_HOST}/ws`;
+
+export const DEFAULT_HUB_STATE = {
+    // this is for the UI only
+    hubConnStatus: "offline",
+
+    // the keys below are shared from central hub.  See hub_state.py
+
+    // provided by central_hub/
+    hub_stats: { state_updates_recv: 0 },
+    //last requested angles
+    set_angles: [],
+    // actual angles last reported by servos
+    current_angles: [],
+
+    // array of json file names provided to central hub
+    // by arms_config_provider
+    arm_config_files: [],
+
+    // initially by arms_config_provider to last selected, can be changed
+    // to any of the arm_configs
+    arm_config_selected: "",
+
+    // currently selected arm config provided by
+    // arms_config_provider
+    arm_config: {
+        filename: "",
+        description: "",
+        arm_parts: [],
+    },
+
+    // saved positions provided initially by saved_positions_provider
+    // and updated by the UI.   This should be an array of objects like:
+    // {
+    //   "name": "some name",
+    //   "description": "some description",
+    //   "angles": [0, 90, 90, 90, 90, 90]
+    // }
+    saved_positions: [],
+
+    subsystem_stats: {},
+};
+
+let __hub_state = { ...DEFAULT_HUB_STATE };
+
+let hubStatePromises: ((value: any) => void)[] = [];
+let onUpdateCallbacks: ((state: typeof DEFAULT_HUB_STATE) => void)[] = [];
+let lastHubUpdate = Date.now();
+let hubMonitor: NodeJS.Timeout | null = null;
+
+export let webSocket: WebSocket | null = null;
+
+export function connectToHub(state = DEFAULT_HUB_STATE) {
+    try {
+        setHubConnStatus("connecting");
+        console.log(`connecting to central-hub at ${HUB_URL}`);
+
+        webSocket = new WebSocket(HUB_URL);
+
+        webSocket.addEventListener("open", function (event) {
+            lastHubUpdate = Date.now();
+
+            try {
+                webSocket!.send(JSON.stringify({ type: "getState" }));
+                webSocket!.send(
+                    JSON.stringify({ type: "identity", data: "webapp" })
+                );
+                webSocket!.send(
+                    JSON.stringify({ type: "subscribeState", data: "*" })
+                );
+                setHubConnStatus("online");
+            } catch (e) {
+                onConnError(state, e);
+            }
+            startHubMonitor();
+        });
+
+        webSocket.addEventListener("error", function (event) {
+            console.error("got error from central-hub socket", event);
+        });
+
+        webSocket.addEventListener("close", function (event) {
+            onConnError(state, event);
+        });
+
+        webSocket.addEventListener("message", function (event) {
+            lastHubUpdate = Date.now();
+            let message = null;
+            try {
+                message = JSON.parse(event.data);
+            } catch (e) {
+                console.error("error parsing message from central-hub", e);
+                return;
+            }
+            if (message.type === "pong") {
+                return;
+            }
+            logMessage("got message from central-hub", {
+                raw: event.data,
+                parsed: message,
+            });
+            if (message.type === "state" && hubStatePromises.length > 0) {
+                hubStatePromises.forEach((p) => p(message.data));
+                hubStatePromises = [];
+            } else if (
+                message.type === "state" ||
+                message.type === "stateUpdate"
+            ) {
+                updateStateFromCentralHub(message.data);
+            }
+        });
+    } catch (e) {
+        onConnError(state, e);
+    }
+}
+
+function startHubMonitor() {
+    stopHubMonitor();
+    hubMonitor = setInterval(() => {
+        // if the socket is hung or there is no network,
+        // the websocket will not error out until we send something
+        webSocket!.send(JSON.stringify({ type: "ping" }));
+
+        if (
+            __hub_state.hubConnStatus === "online" &&
+            Date.now() - lastHubUpdate > MIN_HUB_UPDATE_INTERVAL
+        ) {
+            setHubConnStatus("offline");
+        }
+    }, HUB_PING_INTERVAL);
+}
+
+function stopHubMonitor() {
+    if (hubMonitor) {
+        clearInterval(hubMonitor);
+    }
+}
+
+// handler gets called with __hub_state
+export function addHubStateUpdatedListener(handler: (state: typeof DEFAULT_HUB_STATE) => void) {
+    onUpdateCallbacks.push(handler);
+}
+
+export function removeHubStateUpdatedListener(handler: (state: typeof DEFAULT_HUB_STATE) => void) {
+    const index = onUpdateCallbacks.indexOf(handler);
+    if (index !== -1) {
+        onUpdateCallbacks.splice(index, 1);
+    }
+}
+
+export function getLocalState() {
+    return __hub_state;
+}
+
+export function getStateFromCentralHub() {
+    const statePromise = new Promise<typeof DEFAULT_HUB_STATE>((resolve) =>
+        hubStatePromises.push(resolve)
+    );
+    webSocket!.send(JSON.stringify({ type: "getState" }));
+    return statePromise;
+}
+
+export function updateSharedState(newState: Partial<typeof DEFAULT_HUB_STATE>) {
+    webSocket!.send(JSON.stringify({ type: "updateState", data: newState }));
+}
+
+function delayedConnectToHub(state: typeof DEFAULT_HUB_STATE) {
+    setTimeout(() => {
+        if (state.hubConnStatus === "offline") {
+            connectToHub(state);
+        }
+    }, 5000);
+}
+
+function onConnError(state: typeof DEFAULT_HUB_STATE, e: Event | Error) {
+    console.error(
+        "got close message from central-hub socket. will attempt to reconnnect in 5 seconds",
+        e
+    );
+    stopHubMonitor();
+    setHubConnStatus("offline");
+    delayedConnectToHub(state);
+}
+
+// not exported, should only be called from connectToHub
+function setHubConnStatus(newStatus: string) {
+    logMessage("setting conn status", newStatus);
+    __hub_state.hubConnStatus = newStatus;
+    emitUpdated();
+}
+
+function updateStateFromCentralHub(hubData: Partial<typeof DEFAULT_HUB_STATE>) {
+    for (const [key, value] of Object.entries(hubData)) {
+        // TODO : maybe merge the state with incoming.
+        // State for any top level key must be whole
+        (__hub_state as any)[key] = value;
+    }
+    emitUpdated();
+}
+
+function emitUpdated() {
+    for (const callback of onUpdateCallbacks) {
+        callback(__hub_state);
+    }
+}
+
+export function logMessage(...args: any[]) {
+    if (logMessages) {
+        console.log(...args);
+    }
+}

--- a/src/webapp_ts/src/vars.css
+++ b/src/webapp_ts/src/vars.css
@@ -1,0 +1,13 @@
+:root {
+  --color-black: #222;
+
+  --color-dialog-frame: #def;
+  --color-dialog-content: #658fcf;
+
+  --color-dialog-button: #58e;
+  --color-dialog-button-selected: #c8f;
+
+  --radius-dialog-lg: 60px;
+  --radius-dialog-md: 50px;
+  --radius-dialog-sm: 26px;
+}

--- a/src/webapp_ts/tsconfig.json
+++ b/src/webapp_ts/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
...also remove react-scripts since create-react-app is no longer maintained 🪦

The webapp was originally forked/copied from scatbot repo and was on react 17

This first PR is all Copilot Workspace when asked, "create a new directory src/webapp_ts, bootstrap a react app that uses lastest yarn, typescript, and other packages but do not use react-scripts.   and then port the .js files in src/webapp to typescript and place them in corresponding directories under src/webapp_ts."

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/littlebee/strongarm/pull/6?shareId=4464ad80-f212-4250-9b9d-162b592e71db).