### PR TITLE
Arm angle control current angle should show 0.000

### DIFF
--- a/src/webapp_vite/src/ArmView/ArmAngleControl.tsx
+++ b/src/webapp_vite/src/ArmView/ArmAngleControl.tsx
@@ -157,8 +157,9 @@ export function ArmControl({
     return (
         <div className={st.container}>
             <div className={st.currentAngle}>
-                {!!currentAngle &&
-                    parseFloat(currentAngle.toString()).toFixed(3)}
+                {currentAngle
+                    ? parseFloat(currentAngle.toString()).toFixed(3)
+                    : "0.000"}
                 &deg;
             </div>
             <div className={st.textLabels}>


### PR DESCRIPTION
Expected behavior is that, when set to 0 degress, the angle displayed below the circle shows 0.000.   Current behavior is just showing the degree symbol

My bad.  As pennance, I will spend the rest of the day to get either vitest or jest up and working including a test for the above case.