### PR TITLE
Stop redundant persitance of selected arm config

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -36,14 +36,15 @@ do
 
     base_name=$(basename $sub_system)
     logfile="./logs/$base_name.log"
-    echo "stopping $sub_system at $(date)" >> "$logfile"
-
     pid_file="./$base_name.pid"
     if [ "$STRONGARM_ENV" == "test" ]; then
         echo "stopping test mode process..."
         append=$STRONGARM_FILE_APPEND
+        logfile="./logs/test_$base_name$append.log"
         pid_file="./test_$base_name$append.pid"
     fi
+    echo "stopping $sub_system at $(date)" >> "$logfile"
+
 
     if [ -f "$pid_file" ]; then
         kill -15 `cat $pid_file`

--- a/tests/helpers/start_stop.py
+++ b/tests/helpers/start_stop.py
@@ -43,7 +43,7 @@ def stop_services(service_list: List[str]):
         # the end of the test module, this preserves the logs of the failing test
         print(f"\n {service_name} subsystem logs")
         print("===================================================================")
-        os.system(f"cat logs/{service_name}.py.log")
+        os.system(f"cat logs/test_{service_name}.py.log")
         print("===================================================================")
 
         assert exit_code == 0

--- a/tests/test_arm_configs_provider.py
+++ b/tests/test_arm_configs_provider.py
@@ -60,6 +60,7 @@ class TestArmConfigsProvider:
         assert initial_state["data"]["arm_config"]
         assert len(initial_state["data"]["arm_config"]["arm_parts"]) > 1
         assert len(initial_state["data"]["arm_config_files"]) > 1
+        assert len(initial_state["data"]["arm_config_selected"]) > 1
 
         return initial_state
 


### PR DESCRIPTION
central_hub already persists the selected_arm_config and there is no need for arm_configs_provider to persist it.  Also adds a test of selecting a bogus selected_arm_config.